### PR TITLE
Multiple Fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "cyruscollier/shortcode-ui-richtext",
+  "description": "Plugin for adding rich text editing capabilities to textareas in Shortcake.",
+  "type": "wordpress-plugin",
+  "homepage": "https://github.com/cyruscollier/wp-shortcode-ui-richtext",
+  "license": "GPL-2.0+",
+  "authors": [
+    {
+      "name": "xwp"
+    },
+    {
+      "name": "mihai2u"
+    },
+    {
+      "name": "cyruscollier"
+    }
+  ]
+}
+

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name": "cyruscollier/shortcode-ui-richtext",
+  "name": "xwp/shortcode-ui-richtext",
   "description": "Plugin for adding rich text editing capabilities to textareas in Shortcake.",
   "type": "wordpress-plugin",
-  "homepage": "https://github.com/cyruscollier/wp-shortcode-ui-richtext",
+  "homepage": "https://github.com/xwp/wp-shortcode-ui-richtext",
   "license": "GPL-2.0+",
   "authors": [
     {

--- a/js/richtext.js
+++ b/js/richtext.js
@@ -4,7 +4,8 @@ jQuery(function( $ ) {
 
 	var richTextSelector = 'textarea.shortcake-richtext, #inner_content';
 	var richText = {};
-	var modalFrame;
+	var modalFrame, currentEditor;
+	var loadedEditors = [];
 
 
 	$(document).on('click', '.shortcake-insert-media-modal', function(event){
@@ -41,6 +42,7 @@ jQuery(function( $ ) {
 	 * @returns {boolean}
 	 */
 	richText.load = function( selector ) {
+		currentEditor = wpActiveEditor;
 		if ( ( 'undefined' !== tinyMCE ) && ( $( selector ).length ) ) {
 			$( selector ).each( function() {
 
@@ -63,6 +65,7 @@ jQuery(function( $ ) {
 						// Bind tinyMCE to this field
 						tinyMCE.execCommand('mceAddEditor', false, textarea_id );
 						tinyMCE.execCommand('mceAddControl', false, textarea_id );
+						loadedEditors.push(tinyMCE.get(textarea_id));
 					}, 200);
 
 				}
@@ -82,50 +85,32 @@ jQuery(function( $ ) {
 	 * @returns {boolean}
 	 */
 	richText.unload = function( selector ) {
-
-		if ( ( $( selector ).length ) ) {
-			$( selector ).each( function() {
-				var textarea_id = $( this).attr('id');
-
-				$( this )
-					.text( tinyMCE.get( textarea_id ).getContent() )
-					.trigger( 'input' );
-
-				// Remove tinyMCE from the field
-				tinymce.execCommand( 'mceRemoveEditor', true, textarea_id );
-			});
-
-			// Switch the global active editor back to the WordPress editor
-			wpActiveEditor = 'content';
-
-			return true;
-		} else {
-			return false;
+		var editor;
+		while (editor = loadedEditors.pop()) {
+			var $textarea = $('#' + editor.id);
+			if ($textarea.length) {
+				$textarea.text(editor.getContent())
+					.trigger('input');
+			}
+			editor.remove();
 		}
+
+		// Switch the global active editor back to the WordPress editor
+		wpActiveEditor = currentEditor;
 	};
 
 	if ( 'undefined' !== typeof( wp.shortcake ) ) {
 		wp.shortcake.hooks.addAction( 'shortcode-ui.render_edit', function() {
-
-			// Dynamically bind to newly inserted elements as the action is fired after the field has been added
-			$(document).bind( 'DOMNodeInserted', function(e) {
-				var element = e.target;
-
-				if( $( element ).hasClass( 'shortcode-ui-content-insert' ) ) {
-					richText.loaded = richText.load( $( element ).find( richTextSelector ) );
-				}
-
-			});
-
 			richText.loaded = richText.load( richTextSelector );
 		} );
 		wp.shortcake.hooks.addAction( 'shortcode-ui.render_new', function() {
 			richText.loaded = richText.load( richTextSelector );
 		} );
 		wp.shortcake.hooks.addAction( 'shortcode-ui.render_destroy', function() {
-			if ( richText.loaded ) {
-				richText.unload( richTextSelector );
-			}
+			richText.unload( richTextSelector );
+		} );
+		wp.shortcake.hooks.addAction( 'shortcode-ui.render_closed', function() {
+			richText.unload( richTextSelector );
 		} );
 	}
 

--- a/js/richtext.js
+++ b/js/richtext.js
@@ -100,8 +100,11 @@ jQuery(function( $ ) {
 	};
 
 	if ( 'undefined' !== typeof( wp.shortcake ) ) {
-		wp.shortcake.hooks.addAction( 'shortcode-ui.render_edit', function() {
+		wp.shortcake.hooks.addAction( 'shortcode-ui.render_edit', function(shortcodeModel) {
 			richText.loaded = richText.load( richTextSelector );
+			$('.media-modal .media-modal-close').click(function() {
+                wp.shortcake.hooks.doAction( 'shortcode-ui.render_closed', shortcodeModel );
+			});
 		} );
 		wp.shortcake.hooks.addAction( 'shortcode-ui.render_new', function() {
 			richText.loaded = richText.load( richTextSelector );
@@ -109,6 +112,7 @@ jQuery(function( $ ) {
 		wp.shortcake.hooks.addAction( 'shortcode-ui.render_destroy', function() {
 			richText.unload( richTextSelector );
 		} );
+
 		wp.shortcake.hooks.addAction( 'shortcode-ui.render_closed', function() {
 			richText.unload( richTextSelector );
 		} );

--- a/js/richtext.js
+++ b/js/richtext.js
@@ -103,7 +103,7 @@ jQuery(function( $ ) {
 		wp.shortcake.hooks.addAction( 'shortcode-ui.render_edit', function(shortcodeModel) {
 			richText.loaded = richText.load( richTextSelector );
 			$('.media-modal .media-modal-close').click(function() {
-                wp.shortcake.hooks.doAction( 'shortcode-ui.render_closed', shortcodeModel );
+				wp.shortcake.hooks.doAction( 'shortcode-ui.render_closed', shortcodeModel );
 			});
 		} );
 		wp.shortcake.hooks.addAction( 'shortcode-ui.render_new', function() {


### PR DESCRIPTION
This pull request contains a simple composer file plus multiple fixes:

1. The rich text editor currently does not re-initialize after closing the shortcode modal with the X button rather than the Update button. I fixed this with a simple jQuery event on the X button for now, but I will issue a pull request to the main shortcode-ui plugin to add in the close hook in the modal js itself, which will be more proper.

2. There were some timing issues with the modal and when the target rich text form field was/wasn't in the DOM yet, which didn't allow TinyMCE to properly remove the instances. I fixed this with a local stack of loaded editors which were then unloaded directly with TinyMCE on modal close, so there no longer a need to target elements on unload.

3. Fixed Issue #11 with multiple editors on page.
