### PR TITLE
Change z-index on link popup box

### DIFF
--- a/css/shortcode-ui-richtext.css
+++ b/css/shortcode-ui-richtext.css
@@ -1,7 +1,7 @@
 /* Make sure any popup boxes appear */
 div.mce-inline-toolbar-grp.mce-arrow-up,
 div.mce-floatpanel[style]{
-    z-index: 200000!important;
+    z-index: 500100!important;
 }
 
 /* Add space between the button and the rich text area */


### PR DESCRIPTION
Standard WordPress Core uses, 500100 as z index for popop boxes.
200000 isn't enough, when editing links in the customizer, when the wysiwyg widgets is beeing used.
It should be set to a minimum of the same, at default WordPress Core